### PR TITLE
add HmIP-PMFS Power Outage Detector support

### DIFF
--- a/pyhomematic/devicetypes/actors.py
+++ b/pyhomematic/devicetypes/actors.py
@@ -863,6 +863,7 @@ DEVICETYPES = {
     "HmIP-PS-UK": IPSwitch,
     "HmIP-PCBS": IPSwitch,
     "HmIP-PCBS-BAT": IPSwitch,
+    "HmIP-PMFS": IPSwitch,
     "HmIP-MOD-OC8": IPSwitch,
     "HmIP-BSL": IPKeySwitchLevel,
     "HMIP-PSM": IPSwitchPowermeter,


### PR DESCRIPTION
This pull request:
- adds basic support for new HomeMatic device: HmIP-PMFS - Power Outage Detector,
using the existing IPSwitch class.
see also: [datapoints-HmIP-PMFS.json](https://gist.github.com/k-laus/fb5ca5acb702dba16d27773d6650db64)

inside HomeAssistant, the device is detected as [pyhomematic.devicetypes.generic] HMGeneric.event: ... key=POWER_MAINS_FAILURE, value=False    ... if power is available;
on power outage/disconnect, the key=POWER_MAINS_FAILURE value toggles to True.

Kind regards, Klaus